### PR TITLE
优化AI答题使用，优化登陆二维码显示

### DIFF
--- a/get_websockets.py
+++ b/get_websockets.py
@@ -82,4 +82,8 @@ def print_qrcode(qr_data):
     # 打印二维码
     os.system('cls' if os.name == 'nt' else 'clear')  # 清屏
     print("QRCode:")
-    img.show()
+    qr.print_ascii(invert=True) # 在命令行输出二维码
+    try :
+        img.show()  
+    except:
+        print("无法显示二维码，可以用链接自己生成二维码：", qr_data)

--- a/helper_main.py
+++ b/helper_main.py
@@ -99,6 +99,17 @@ if __name__ == "__main__":
             continue
         elif int(number) == 0:
             flag = False  # 输入合法则不需要循环
+            # 做不做作业
+            while True:
+                choice_hw = input("需不需要AI做作业（Y/N）：").strip()
+                if choice_hw in ('Y', 'y'):
+                    choice_hw = True
+                    break
+                elif choice_hw in ('N', 'n'):
+                    choice_hw = False
+                    break
+                else:
+                    print("输入无效，请输入 Y 或 N。")
             # 0 表示全部刷一遍
             for ins in courses:
                 videos_id_name_dic = video_helper.get_videos_ids(
@@ -110,14 +121,28 @@ if __name__ == "__main__":
                 video_helper.multiple_watch_video(
                     videos_id_name_dic, course_id, user_id, classroom_id, sku_id
                 )
-            for ins in courses:
-                homework_helper.do_homework(
-                    ins["classroom_id"],
-                    ins["course_sign"],
-                    ins["course_name"],
-                )
+            if choice_hw:  # 如果选择做作业，执行
+                for ins in courses:
+                    homework_helper.do_homework(
+                        ins["classroom_id"],
+                        ins["course_sign"],
+                        ins["course_name"],
+                    )
+            else:
+                pass
         else:
             flag = False  # 输入合法则不需要循环
+            # 做不做作业
+            while True:
+                choice_hw = input("需不需要AI做作业（Y/N）：").strip()
+                if choice_hw in ('Y', 'y'):
+                    choice_hw = True
+                    break
+                elif choice_hw in ('N', 'n'):
+                    choice_hw = False
+                    break
+                else:
+                    print("输入无效，请输入 Y 或 N。")
             # 指定序号的课程刷一遍
             number = int(number) - 1
             videos_id_name_dic = video_helper.get_videos_ids(
@@ -132,9 +157,12 @@ if __name__ == "__main__":
             video_helper.multiple_watch_video(
                 videos_id_name_dic, course_id, user_id, classroom_id, sku_id
             )
-            homework_helper.do_homework(
-                courses[number]["classroom_id"],
-                courses[number]["course_sign"],
-                courses[number]["course_name"],
-            )
+            if choice_hw:  # 如果选择做作业，执行
+                homework_helper.do_homework(
+                    courses[number]["classroom_id"],
+                    courses[number]["course_sign"],
+                    courses[number]["course_name"],
+                )
+            else:
+                pass
         print("搞定啦")

--- a/openai_ask.py
+++ b/openai_ask.py
@@ -1,6 +1,6 @@
 from openai import OpenAI
 import json
-
+import re
 
 class OpenAI_ask:
     def __init__(self):
@@ -29,11 +29,19 @@ class OpenAI_ask:
             ],
             temperature=0.7,
         )
-        if len(response.choices[0].message.content) == 1 or problem_type == 'FillBlank' or leaf_type == 4:
-            result = response.choices[0].message.content
+        # 1. 获取模型返回的原始全文
+        full_content = response.choices[0].message.content
+
+        # 2. 使用正则剔除 <think>...</think> 及其包含的所有内容
+        # flags=re.DOTALL 确保可以匹配跨行的思考过程
+        nothink_content = re.sub(r'<think>.*?</think>', '', full_content, flags=re.DOTALL).strip()
+
+        # 3. 基于清洗后的内容进行原有逻辑判断
+        if len(nothink_content) == 1 or problem_type == 'FillBlank' or leaf_type == 4:
+            result = nothink_content
         else:
             result = [
-                item.strip() for item in response.choices[0].message.content.split(",")
+                item.strip() for item in nothink_content.split(",") if item.strip()
             ]
         #print(f"result:\n{result}\n")
         return result


### PR DESCRIPTION
1. 由于在使用带思考的模型（例如deepseek）时回复会带`<think>\n...\n</think>`标签，导致传入`do_homework`的答案杂乱，完全不正确。使用正则去掉标签即可。
2. 让用户可以选择是否做作业，在选择课程后进行选择。
3. 登陆时直接在命令行显示二维码，并且在显示图像失败时回退到输出链接让用户自己生成二维码（受到[VermiIIi0n/fuckZHS: 自动刷智慧树课程的脚本](https://github.com/VermiIIi0n/fuckZHS)启发）