### PR TITLE
fix(homework): support ShortAnswer and Judgement problem types

### DIFF
--- a/homeworkHelper.py
+++ b/homeworkHelper.py
@@ -139,7 +139,7 @@ class homeworkHelper:
                     continue
                 if content["Type"] != 'FillBlank':  # 填空题
                     options = [
-                        f"{opt['key']}. {opt['value']}" for opt in content["Options"]
+                        f"{opt['key']}. {opt['value']}" for opt in content.get("Options", [])
                     ]
                     # 构建值字符串（不再需要包含ID）
                     questions_info = {"Type": content["Type"], "Body": content["Body"], "Options": options}

--- a/openai_ask.py
+++ b/openai_ask.py
@@ -37,7 +37,15 @@ class OpenAI_ask:
         nothink_content = re.sub(r'<think>.*?</think>', '', full_content, flags=re.DOTALL).strip()
 
         # 3. 基于清洗后的内容进行原有逻辑判断
-        if len(nothink_content) == 1 or problem_type == 'FillBlank' or leaf_type == 4:
+        # FillBlank 保留为字符串以便 homeworkHelper 走 json.loads
+        # 讨论 (leaf_type==4) 也保留为字符串原文使用
+        # SingleChoice "C" / Judgement "true"/"false" / Essay 长文本：无逗号 → 字符串
+        # MultipleChoice "A, B"：含逗号 → 列表
+        if (
+            problem_type == "FillBlank"
+            or leaf_type == 4
+            or "," not in nothink_content
+        ):
             result = nothink_content
         else:
             result = [


### PR DESCRIPTION
## 复现

又发现一种新的主观题类型`ShortAnswer`

运行中报错：
```
Traceback (most recent call last):
  File "yuketangHelperBUU\helper_main.py", line 161, in <module>
    homework_helper.do_homework(
  File "yuketangHelperBUU\homeworkHelper.py", line 142, in do_homework
    f"{opt['key']}. {opt['value']}" for opt in content["Options"]
                                               ~~~~~~~^^^^^^^^^^^
KeyError: 'Options'
```
原脚本在第一道 `ShortAnswer` 上抛 `KeyError: 'Options'`，整个作业循环直接退出。

## 根因

**`homeworkHelper.py:142`** 的 `content["Options"]` 假设所有非 `FillBlank` 题型都带 `Options` 数组。Yuketang 的 `ShortAnswer`（主观题）只含 `Body` + `AllowResults`，没有选项数组。


## 修复

- `homeworkHelper.py:142`：`content["Options"]` → `content.get("Options", [])`


## 验证

- 处理 110 题（100 `SingleChoice` + 10 `ShortAnswer`），无崩溃
